### PR TITLE
test if this is the right change for the download url

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach by Process ID",
+      "processId": "${command:PickProcess}"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "program": "${workspaceFolder}/bin/web.js"
+    }
+  ]
+}

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -331,13 +331,16 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
         return that.backend.readAsset(asset)
         .then(function(content) {
             var releases = winReleases.parse(content.toString('utf-8'));
+            console.log("releases", releases);
 
             releases = _.chain(releases)
 
                 // Change filename to use download proxy
-                .map(function(entry) {
+                .map(function (entry) {
+                    console.log("entryBefore", entry);
                     var gitFilePath = (channel === '*' ? '../../../../' : '../../../../../../');
-                    entry.filename = urljoin(fullUrl, gitFilePath, '/download/'+entry.version+'/'+entry.filename);
+                    entry.filename = urljoin(fullUrl, gitFilePath, '/download/' + entry.version + '/' + entry.filename);
+                    console.log("entry", entry);
 
                     return entry;
                 })

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -334,12 +334,11 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
             console.log("releases", releases);
 
             releases = _.chain(releases)
-
                 // Change filename to use download proxy
                 .map(function (entry) {
                     console.log("entryBefore", entry);
                     var gitFilePath = (channel === '*' ? '../../../../' : '../../../../../../');
-                    entry.filename = urljoin(fullUrl, gitFilePath, '/download/' + entry.version + '/' + entry.filename);
+                    entry.filename = urljoin(fullUrl, gitFilePath, '/download/' + entry.semver + '/' + entry.filename);
                     console.log("entry", entry);
 
                     return entry;

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -337,7 +337,7 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
                 // Change filename to use download proxy
                 .map(function(entry) {
                     var gitFilePath = (channel === '*' ? '../../../../' : '../../../../../../');
-                    entry.filename = urljoin(fullUrl, gitFilePath, '/download/'+entry.semver+'/'+entry.filename);
+                    entry.filename = urljoin(fullUrl, gitFilePath, '/download/'+entry.version+'/'+entry.filename);
 
                     return entry;
                 })

--- a/lib/utils/win-releases.js
+++ b/lib/utils/win-releases.js
@@ -65,13 +65,35 @@ function parseRELEASES(content) {
 
             var filename = parts[2];
             var isDelta = filename.indexOf('-full.nupkg') == -1;
-
+            var isBeta = filename.indexOf('beta') !== -1;
+            var isAlpha = filename.indexOf('alpha') !== -1;
+            var isUnstable = filename.indexOf('unstable') !== -1;
+            var isRc = filename.indexOf('rc') !== -1;
+            //filename = "sufferfest-5.2.3-beta.5-full.nupkg"
             var filenameParts = filename
                 .replace(".nupkg", "")
                 .replace("-delta", "")
                 .replace("-full", "")
+                .replace("beta", "")
+                .replace("alpha", "")
+                .replace("unstable", "")
+                .replace("rc", "")
                 .split(/\.|-/)
                 .reverse();
+
+            if (filenameParts.length >= 4) {
+                let offset = 0;
+                if (isAlpha) {
+                    offset = 1000;
+                } else if (isBeta) {
+                    offset = 2000;
+                } else if (isUnstable) {
+                    offset = 3000;
+                } else if (isRc) {
+                    offset = 4000;
+                }
+                filenameParts[0] = parseInt(filenameParts[0], 10) + offset;
+            }
 
             var version = _.chain(filenameParts)
                 .filter(function(x) {
@@ -80,6 +102,7 @@ function parseRELEASES(content) {
                 .reverse()
                 .value()
                 .join('.');
+
 
             return {
                 sha: parts[1],


### PR DESCRIPTION
Fixes the returned release file for beta versions on windows:

This url
https://releases.thesufferfest.com/update/channel/beta/win32_ia32/5.2.3-beta.1/releases?id=sufferfest&localversion=5.2.3-beta1&arch=amd64
will return a releases file with this:
AA6FCB119272E0CAAA1267B8B237A17CB5E06E3E http://releases.thesufferfest.com/download/5.2.3/sufferfest-5.2.3-beta5-full.nupkg 57564342

It should have 5.2.3-beta.5 after /download/ though. 

Ensure that this PR fixes that. 

To run locally and debug:
1. make sure you have heroku cli installed. 
1. modify procfile to: web: node --inspect bin/web.js
1. run `heroku local` from command line
1. in VS Code, use the `attach to process by ID` launch configuration.
You should be able to hit breakpoints in the code now. You can test with this url:
http://localhost:5000/update/channel/beta/win32_ia32/5.2.0/RELEASES?id=sufferfest&localVersion=5.2.0&arch=amd64