### PR TITLE
Fix architecture name detection

### DIFF
--- a/lib/utils/platforms.js
+++ b/lib/utils/platforms.js
@@ -27,6 +27,7 @@ function platformToType(platform) {
 }
 
 // Detect and normalize the platform name
+// Used for file names as well as platform strings
 function detectPlatform(platform) {
     var name = platform.toLowerCase();
     var prefix = "", suffix = "";
@@ -64,8 +65,9 @@ function detectPlatform(platform) {
     // Detect suffix: 32 or 64
     if (_.contains(name, 'x86')
         || _.contains(name, 'ia32')
-        || _.contains(name, 'i386')) suffix = '32';
-    if (_.contains(name, 'x86_64') || _.contains(name, 'x64') || _.contains(name, 'amd64')) suffix = '64';
+        || _.contains(name, 'i386')
+        || _.contains(name, prefix+'_32')) suffix = '32';
+    if (_.contains(name, 'x86_64') || _.contains(name, 'x64') || _.contains(name, 'amd64') || _.contains(name, prefix+'_64')) suffix = '64';
 
     suffix = suffix || (prefix == platforms.OSX? '64' : '32');
     return _.compact([prefix, suffix]).join('_');

--- a/lib/utils/platforms.js
+++ b/lib/utils/platforms.js
@@ -62,10 +62,10 @@ function detectPlatform(platform) {
         || hasSuffix(name, '.dmg')) prefix = platforms.OSX;
 
     // Detect suffix: 32 or 64
-    if (_.contains(name, '32')
+    if (_.contains(name, 'x86')
         || _.contains(name, 'ia32')
         || _.contains(name, 'i386')) suffix = '32';
-    if (_.contains(name, '64') || _.contains(name, 'x64') || _.contains(name, 'amd64')) suffix = '64';
+    if (_.contains(name, 'x86_64') || _.contains(name, 'x64') || _.contains(name, 'amd64')) suffix = '64';
 
     suffix = suffix || (prefix == platforms.OSX? '64' : '32');
     return _.compact([prefix, suffix]).join('_');

--- a/test/platforms.js
+++ b/test/platforms.js
@@ -11,8 +11,14 @@ describe('Platforms', function() {
 
         it('should detect windows_32', function() {
             platforms.detect('myapp-v0.25.1-win32-ia32.zip').should.be.exactly(platforms.WINDOWS_32);
+            platforms.detect('myapp-v0.25.1-win32-x86.zip').should.be.exactly(platforms.WINDOWS_32);
             platforms.detect('atom-1.0.9-delta.nupkg').should.be.exactly(platforms.WINDOWS_32);
             platforms.detect('RELEASES').should.be.exactly(platforms.WINDOWS_32);
+        });
+
+        it('should detect windows_64', function() {
+            platforms.detect('myapp-v0.25.1-win64-x64.zip').should.be.exactly(platforms.WINDOWS_64);
+            platforms.detect('myapp-v0.25.1-win64-x86_64.zip').should.be.exactly(platforms.WINDOWS_64);
         });
 
         it('should detect linux', function() {
@@ -38,6 +44,13 @@ describe('Platforms', function() {
             platforms.detect('atom-amd64.rpm').should.be.exactly(platforms.LINUX_RPM_64);
         });
 
+        it('should not interpret version as arch', function() {
+            platforms.detect('APP-1.0.5-alpha.325.dmg').should.be.exactly(platforms.OSX_64);
+            platforms.detect('APP-32.32.32-alpha.32323232.dmg').should.be.exactly(platforms.OSX_64);
+            platforms.detect('APP-32.32.32-alpha.32323232-darwin-64.zip').should.be.exactly(platforms.OSX_64);
+            platforms.detect('APP-64.64.64-alpha.64.nupkg').should.be.exactly(platforms.WINDOWS_32);
+            platforms.detect('APP-64.64.64-alpha.64.exe').should.be.exactly(platforms.WINDOWS_32);
+        });
     });
 
     describe('Resolve', function() {


### PR DESCRIPTION
Versions in file names were incorrectly being detected as architecture bit types, so APP-0.0.0-alpha.320.dmg was being detected as a 32 bit file when it isn't.

The strings now require more specificity before they are considered a file type. x86 and x64 were used in place of 32 and 64.
The same function was being used to detect platform types. To keep that functionality, it also now detects platformName_32 and platformName_64 as bit types. Ex: linux_64 is 64 bit.

Added unit tests to the platform tests. Running all unit tests will fail because some of the update tests were failing on master, but I didn't look very far into why.