### PR TITLE
Support Alpha channels

### DIFF
--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -243,7 +243,9 @@ Nuts.prototype.onUpdateRedirect = function(req, res, next) {
 
 function determineChannel(req) {
     if(req.params.version && req.params.version.indexOf('beta') !== -1) {
-        return '*';
+        return 'beta';
+    } if(req.params.version && req.params.version.indexOf('alpha') !== -1) {
+        return 'alpha';
     } else {
         return 'stable';
     }

--- a/test/update.js
+++ b/test/update.js
@@ -32,7 +32,7 @@ describe('Update', function() {
                 .get('/update/osx/0.9.1-beta')
                 .expect('Content-Type', /json/)
                 .expect(function(res) {
-                    expect(res.body.name).toBe('1.0.0');
+                    expect(res.body.name).toBe('1.0.1-beta.0');
                 })
                 .expect(200, done);
             });
@@ -42,7 +42,7 @@ describe('Update', function() {
                 .get('/update/osx/0.9.1-beta.1')
                 .expect('Content-Type', /json/)
                 .expect(function(res) {
-                    expect(res.body.name).toBe('1.0.0');
+                    expect(res.body.name).toBe('1.0.1-beta.0');
                 })
                 .expect(200, done);
             });
@@ -52,7 +52,7 @@ describe('Update', function() {
                 .get('/update/osx/0.9.2-alpha.2')
                 .expect('Content-Type', /json/)
                 .expect(function(res) {
-                    expect(res.body.name).toBe('1.0.0');
+                    expect(res.body.name).toBe('1.1.0-alpha.0');
                 })
                 .expect(200, done);
             });


### PR DESCRIPTION
Update request channels now only update to the latest version on their own channel. An alpha version will only update to an alpha version even if there is a newer beta, etc.

I also updated the unit tests to reflect expected results. The update channel tests do a decent job of exercising this functionality and can be run with `npm test` in the base dir of the repo.