### PR TITLE
Bump the windows releases normalization up to be less restrictive

### DIFF
--- a/lib/utils/win-releases.js
+++ b/lib/utils/win-releases.js
@@ -3,7 +3,7 @@ var semver = require('semver');
 var stripBom = require('strip-bom');
 
 // Ordered list of supported channel
-var CHANNEL_MAGINITUDE = 1000;
+var CHANNEL_MAGINITUDE = 100000;
 var CHANNELS = [
     'alpha', 'beta', 'unstable', 'rc'
 ];
@@ -84,13 +84,13 @@ function parseRELEASES(content) {
             if (filenameParts.length >= 4) {
                 let offset = 0;
                 if (isAlpha) {
-                    offset = 1000;
+                    offset = 100000;
                 } else if (isBeta) {
-                    offset = 2000;
+                    offset = 200000;
                 } else if (isUnstable) {
-                    offset = 3000;
+                    offset = 300000;
                 } else if (isRc) {
-                    offset = 4000;
+                    offset = 400000;
                 }
                 filenameParts[0] = parseInt(filenameParts[0], 10) + offset;
             }

--- a/test/win-releases.js
+++ b/test/win-releases.js
@@ -11,17 +11,17 @@ describe('Windows RELEASES', function() {
         });
 
         it('should normalize the pre-release', function() {
-            winReleases.normVersion('1.0.0-alpha.1').should.be.exactly('1.0.0.1001');
-            winReleases.normVersion('1.0.0-beta.1').should.be.exactly('1.0.0.2001');
-            winReleases.normVersion('1.0.0-unstable.1').should.be.exactly('1.0.0.3001');
-            winReleases.normVersion('1.0.0-rc.1').should.be.exactly('1.0.0.4001');
+            winReleases.normVersion('1.0.0-alpha.1').should.be.exactly('1.0.0.100001');
+            winReleases.normVersion('1.0.0-beta.1').should.be.exactly('1.0.0.200001');
+            winReleases.normVersion('1.0.0-unstable.1').should.be.exactly('1.0.0.300001');
+            winReleases.normVersion('1.0.0-rc.1').should.be.exactly('1.0.0.400001');
             winReleases.normVersion('1.0.0-14').should.be.exactly('1.0.0.14');
         });
 
         it('should correctly return to a semver', function() {
-            winReleases.toSemver('1.0.0.1001').should.be.exactly('1.0.0-alpha.1');
-            winReleases.toSemver('1.0.0.2001').should.be.exactly('1.0.0-beta.1');
-            winReleases.toSemver('1.0.0.2015').should.be.exactly('1.0.0-beta.15');
+            winReleases.toSemver('1.0.0.100001').should.be.exactly('1.0.0-alpha.1');
+            winReleases.toSemver('1.0.0.200001').should.be.exactly('1.0.0-beta.1');
+            winReleases.toSemver('1.0.0.200015').should.be.exactly('1.0.0-beta.15');
             winReleases.toSemver('1.0.0').should.be.exactly('1.0.0');
         });
 


### PR DESCRIPTION
The windows releases are normalizing the prerelease type into a flat int that had a low enough ceiling we overflowed into the next release type from alpha to beta. IE: Alpha 1001 was interpreted as Beta 1. This bumps up the offset to be considerably less restrictive.