### PR TITLE
Windows beta versions not updating between patch numbers

### DIFF
--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -324,7 +324,8 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
         return that.versions.filter({
             tag: '>='+tag,
             platform: platform,
-            channel: channel
+            channel: channel,
+            stripChannel : true
         });
     })
     .then(function(versions) {

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -342,7 +342,7 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
         return that.backend.readAsset(asset)
         .then(function(content) {
             var releases = winReleases.parse(content.toString('utf-8'));
-            console.log("releases", releases);
+            // console.log("releases", releases);
 
             releases = _.chain(releases)
                 // Change filename to use download proxy

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -341,7 +341,7 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
         return that.backend.readAsset(asset)
         .then(function(content) {
             var releases = winReleases.parse(content.toString('utf-8'));
-            // console.log("releases", releases);
+            console.log("releases", releases);
 
             releases = _.chain(releases)
                 // Change filename to use download proxy

--- a/test/win-releases.js
+++ b/test/win-releases.js
@@ -11,7 +11,7 @@ describe('Windows RELEASES', function() {
         });
 
         it('should normalize the pre-release', function() {
-            winReleases.normVersion('1.0.0-alpha.1').should.be.exactly('1.0.0.100001');
+            winReleases.normVersion('1.0.1-alpha.1').should.be.exactly('1.0.1.100001');
             winReleases.normVersion('1.0.0-beta.1').should.be.exactly('1.0.0.200001');
             winReleases.normVersion('1.0.0-unstable.1').should.be.exactly('1.0.0.300001');
             winReleases.normVersion('1.0.0-rc.1').should.be.exactly('1.0.0.400001');
@@ -19,9 +19,9 @@ describe('Windows RELEASES', function() {
         });
 
         it('should correctly return to a semver', function() {
-            winReleases.toSemver('1.0.0.100001').should.be.exactly('1.0.0-alpha.1');
+            winReleases.toSemver('1.0.1.100001').should.be.exactly('1.0.1-alpha.1');
             winReleases.toSemver('1.0.0.200001').should.be.exactly('1.0.0-beta.1');
-            winReleases.toSemver('1.0.0.200015').should.be.exactly('1.0.0-beta.15');
+            winReleases.toSemver('9.3.7.200015').should.be.exactly('9.3.7-beta.15');
             winReleases.toSemver('1.0.0').should.be.exactly('1.0.0');
         });
 


### PR DESCRIPTION
semver.satisfies doesn't allow >=7.0.0-beta.1 to be satisfied by 7.0.1-beta.2 because it will return false for prelease versions that jump patch numbers.

Because we already jump patch numbers in prerelease on mac, this change makes the behavior consistent and allows our alpha/beta updates to move between patches.