### PR TITLE
Use S3 accelerate to hit the CDN instead of directly to the bucket on…

### DIFF
--- a/lib/backends/s3.js
+++ b/lib/backends/s3.js
@@ -65,7 +65,7 @@ S3Backend.prototype._releases = function() {
                 size: object.Size,
                 content_type: 'application/octet-stream',
                 path: object.Key,
-                url: `https://${bucket}.s3.amazonaws.com/${object.Key}`
+                url: `https://${bucket}.s3-accelerate.amazonaws.com/${object.Key}`
             });
         });
 


### PR DESCRIPTION
Use the S3-accelerate endpoint to get an edge-cached version of the file instead of hitting the bucket directly on the east coast.